### PR TITLE
Add option to use record timestamp instead of 'now'

### DIFF
--- a/lib/fluent/plugin/out_timestamper.rb
+++ b/lib/fluent/plugin/out_timestamper.rb
@@ -5,30 +5,47 @@ module Fluent
     config_param :tag, :string
     config_param :key, :string
     config_param :format, :string
+    config_param :source, :string, :default => "now"
 
     def configure(conf)
       super
+      case @source
+      when "now"
+        @time_getter = method(:get_time_now)
+      when "record"
+        @time_getter = method(:get_time_record)
+      else
+        raise ConfigError, "timestamper: Unknown source : " + @source
+      end
     end
 
     def emit(tag, es, chain)
-      now = Time.now
-
       es.each do |time, record|
+        the_time = @time_getter.call(time)
         case @format
         when "seconds"
-          record[@key] = now.to_i
+          record[@key] = the_time.to_i
         when "milliseconds"
-          record[@key] = (now.to_i * 1000) + (now.usec / 1000.0).round
+          record[@key] = (the_time.to_i * 1000) + (the_time.usec / 1000.0).round
         when "iso8601"
-          record[@key] = now.iso8601
+          record[@key] = the_time.iso8601
         else
-          record[@key] = now.strftime(@format)
+          record[@key] = the_time.strftime(@format)
         end
 
         Fluent::Engine.emit(@tag, time, record)
       end
 
       chain.next
+    end
+
+    private 
+    def get_time_now(record_time)
+      return Time.now
+    end
+
+    def get_time_record(record_time)
+      return Time.at(record_time).utc
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,12 +1,4 @@
-require 'bundler'
 
-begin
-  Bundler.setup(:default, :development)
-rescue Bundler::BundlerError => e
-  $stderr.puts e.message
-  $stderr.puts "Run `bundle install` to install missing gems"
-  exit e.status_code
-end
 require 'test/unit'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/test/plugin/test_out_timestamper.rb
+++ b/test/plugin/test_out_timestamper.rb
@@ -23,6 +23,15 @@ class TimestamperOutputTest < Test::Unit::TestCase
     ] end
   end
 
+  def test_bad_standard
+    assert_raise do create_driver %[
+      tag #{@tag}
+      key #{@key}
+      format seconds
+      standard badstandard
+    ] end
+  end
+
   def test_format_seconds
     d = create_driver %[
       tag #{@tag}
@@ -76,16 +85,17 @@ class TimestamperOutputTest < Test::Unit::TestCase
     d = create_driver %[
       tag #{@tag}
       key #{@key}
-      format %X
+      format %d/%b/%Y:%H:%M:%S %z
       source record
+      standard localtime
     ]
 
     d.run do
-      d.emit({"a"=>1}, Time.parse("1990-04-14 11:45:15 UTC").to_i)
+      d.emit({"a"=>1}, Time.parse("1990-04-14 09:45:15 UTC").to_i)
     end
 
     record = d.emits.first.last
-    assert_equal Time.parse("1990-04-14 11:45:15 UTC").strftime("%X"), record[@key]
+    assert_equal "14/Apr/1990:11:45:15 +0200", record[@key]
   end
 
   private


### PR DESCRIPTION
The time in record is Now when the input source doesn't contain time instructions.

However, some input Plugin uses source log lines to define "time of the record".

As a result, sometimes we want to play with current time, but often we want to play with actual record time (exact time of each log line, for example).

Adding "source record" option formats time of the record instead of current time.
